### PR TITLE
[#14]feat: 그룹 거래 내역 등록/조회 기능 구현

### DIFF
--- a/src/main/java/com/dalcoomi/team/infrastructure/TeamMemberRepositoryImpl.java
+++ b/src/main/java/com/dalcoomi/team/infrastructure/TeamMemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dalcoomi.team.infrastructure;
 
+import static com.dalcoomi.common.jpa.DynamicQuery.generateEq;
 import static com.dalcoomi.member.infrastructure.QMemberJpaEntity.memberJpaEntity;
 import static com.dalcoomi.team.infrastructure.QTeamJpaEntity.teamJpaEntity;
 import static com.dalcoomi.team.infrastructure.QTeamMemberJpaEntity.teamMemberJpaEntity;
@@ -11,7 +12,6 @@ import java.util.Map;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
-import com.dalcoomi.common.jpa.DynamicQuery;
 import com.dalcoomi.team.application.repository.TeamMemberRepository;
 import com.dalcoomi.team.domain.TeamMember;
 import com.dalcoomi.team.dto.QTeamMemberProjection_TeamMemberCountDto;
@@ -44,8 +44,8 @@ public class TeamMemberRepositoryImpl implements TeamMemberRepository {
 			.join(teamMemberJpaEntity.team, teamJpaEntity).fetchJoin()
 			.join(teamMemberJpaEntity.member, memberJpaEntity).fetchJoin()
 			.where(
-				DynamicQuery.generateEq(teamId, teamJpaEntity.id::eq),
-				DynamicQuery.generateEq(memberId, memberJpaEntity.id::eq),
+				generateEq(teamId, teamJpaEntity.id::eq),
+				generateEq(memberId, memberJpaEntity.id::eq),
 				memberJpaEntity.deletedAt.isNull()
 			)
 			.fetch()

--- a/src/main/java/com/dalcoomi/transaction/application/TransactionService.java
+++ b/src/main/java/com/dalcoomi/transaction/application/TransactionService.java
@@ -1,5 +1,7 @@
 package com.dalcoomi.transaction.application;
 
+import static com.dalcoomi.common.error.model.ErrorMessage.TEAM_MEMBER_NOT_FOUND;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -7,10 +9,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dalcoomi.category.application.repository.CategoryRepository;
 import com.dalcoomi.category.domain.Category;
+import com.dalcoomi.common.error.exception.NotFoundException;
 import com.dalcoomi.member.application.repository.MemberRepository;
 import com.dalcoomi.member.domain.Member;
+import com.dalcoomi.team.application.repository.TeamMemberRepository;
 import com.dalcoomi.transaction.application.repository.TransactionRepository;
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 import com.dalcoomi.transaction.dto.TransactionsInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -22,9 +27,12 @@ public class TransactionService {
 	private final TransactionRepository transactionRepository;
 	private final MemberRepository memberRepository;
 	private final CategoryRepository categoryRepository;
+	private final TeamMemberRepository teamMemberRepository;
 
 	@Transactional
 	public void createTransaction(Long memberId, Long categoryId, Transaction transaction) {
+		validateTeamMember(transaction.getTeamId(), memberId);
+
 		Member member = memberRepository.findById(memberId);
 		Category category = categoryRepository.findById(categoryId);
 
@@ -35,14 +43,16 @@ public class TransactionService {
 	}
 
 	@Transactional(readOnly = true)
-	public TransactionsInfo getTransactionsByMemberIdAndYearAndMonth(Long memberId, int year, int month) {
-		List<Transaction> transactions = transactionRepository.findByCreatorIdAndYearAndMonth(memberId, year, month);
+	public TransactionsInfo getTransactions(TransactionSearchCriteria criteria) {
+		validateTeamMember(criteria.teamId(), criteria.requesterId());
+
+		List<Transaction> transactions = transactionRepository.findTransactions(criteria);
 
 		return TransactionsInfo.from(transactions);
 	}
 
 	@Transactional(readOnly = true)
-	public Transaction getTransactionsById(Long memberId, Long transactionId) {
+	public Transaction getMyTransaction(Long memberId, Long transactionId) {
 		return transactionRepository.findByIdAndCreatorId(transactionId, memberId);
 	}
 
@@ -67,5 +77,15 @@ public class TransactionService {
 		transaction.softDelete();
 
 		transactionRepository.save(transaction);
+	}
+
+	private void validateTeamMember(Long teamId, Long memberId) {
+		if (teamId == null) {
+			return;
+		}
+
+		if (!teamMemberRepository.existsByTeamIdAndMemberId(teamId, memberId)) {
+			throw new NotFoundException(TEAM_MEMBER_NOT_FOUND);
+		}
 	}
 }

--- a/src/main/java/com/dalcoomi/transaction/application/repository/TransactionRepository.java
+++ b/src/main/java/com/dalcoomi/transaction/application/repository/TransactionRepository.java
@@ -3,6 +3,7 @@ package com.dalcoomi.transaction.application.repository;
 import java.util.List;
 
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 
 public interface TransactionRepository {
 
@@ -12,9 +13,7 @@ public interface TransactionRepository {
 
 	Transaction findByIdAndCreatorId(Long transactionId, Long creatorId);
 
-	List<Transaction> findByCreatorIdAndYearAndMonth(Long creatorId, int year, int month);
-
-	List<Transaction> findByTeamId(Long teamId);
+	List<Transaction> findTransactions(TransactionSearchCriteria criteria);
 
 	void deleteByTeamId(Long groupId);
 }

--- a/src/main/java/com/dalcoomi/transaction/domain/Transaction.java
+++ b/src/main/java/com/dalcoomi/transaction/domain/Transaction.java
@@ -47,6 +47,7 @@ public class Transaction {
 
 	public static Transaction from(TransactionRequest request) {
 		return Transaction.builder()
+			.teamId(request.teamId())
 			.amount(request.amount())
 			.content(request.content())
 			.transactionDate(request.transactionDate())

--- a/src/main/java/com/dalcoomi/transaction/dto/TransactionSearchCriteria.java
+++ b/src/main/java/com/dalcoomi/transaction/dto/TransactionSearchCriteria.java
@@ -1,0 +1,25 @@
+package com.dalcoomi.transaction.dto;
+
+import org.springframework.lang.Nullable;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionSearchCriteria(
+	Long requesterId,
+	Long memberId,
+	Long teamId,
+	Integer year,
+	Integer month
+) {
+
+	public static TransactionSearchCriteria of(Long memberId, @Nullable Long teamId, Integer year, Integer month) {
+		return TransactionSearchCriteria.builder()
+			.requesterId(memberId)
+			.memberId(teamId == null ? memberId : null)
+			.teamId(teamId)
+			.year(year)
+			.month(month)
+			.build();
+	}
+}

--- a/src/main/java/com/dalcoomi/transaction/dto/request/TransactionRequest.java
+++ b/src/main/java/com/dalcoomi/transaction/dto/request/TransactionRequest.java
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record TransactionRequest(
+	Long teamId,
+
 	@NotNull(message = "금액은 필수입니다.")
 	@Positive(message = "자연수를 입력해주세요.")
 	Long amount,

--- a/src/main/java/com/dalcoomi/transaction/dto/response/GetTransactionsResponse.java
+++ b/src/main/java/com/dalcoomi/transaction/dto/response/GetTransactionsResponse.java
@@ -10,19 +10,19 @@ import com.dalcoomi.transaction.dto.TransactionsInfo;
 import lombok.Builder;
 
 @Builder
-public record GetMyTransactionsResponse(
+public record GetTransactionsResponse(
 	Long income,
 	Long expense,
 	Long total,
 	List<GetMyTransactionResponseItem> transactions
 ) {
 
-	public static GetMyTransactionsResponse from(TransactionsInfo transactionsInfo) {
+	public static GetTransactionsResponse from(TransactionsInfo transactionsInfo) {
 		List<GetMyTransactionResponseItem> transactions = transactionsInfo.transactions().stream()
 			.map(GetMyTransactionResponseItem::from)
 			.toList();
 
-		return GetMyTransactionsResponse.builder()
+		return GetTransactionsResponse.builder()
 			.income(transactionsInfo.income())
 			.expense(transactionsInfo.expense())
 			.total(transactionsInfo.total())

--- a/src/main/java/com/dalcoomi/transaction/infrastructure/TransactionRepositoryImpl.java
+++ b/src/main/java/com/dalcoomi/transaction/infrastructure/TransactionRepositoryImpl.java
@@ -2,10 +2,10 @@ package com.dalcoomi.transaction.infrastructure;
 
 import static com.dalcoomi.category.infrastructure.QCategoryJpaEntity.categoryJpaEntity;
 import static com.dalcoomi.common.error.model.ErrorMessage.TRANSACTION_NOT_FOUND;
+import static com.dalcoomi.common.jpa.DynamicQuery.generateEq;
 import static com.dalcoomi.member.infrastructure.QMemberJpaEntity.memberJpaEntity;
 import static com.dalcoomi.transaction.infrastructure.QTransactionJpaEntity.transactionJpaEntity;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import com.dalcoomi.common.error.exception.NotFoundException;
 import com.dalcoomi.transaction.application.repository.TransactionRepository;
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -44,32 +45,23 @@ public class TransactionRepositoryImpl implements TransactionRepository {
 	}
 
 	@Override
-	public List<Transaction> findByCreatorIdAndYearAndMonth(Long creatorId, int year, int month) {
-		LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
-		LocalDateTime endDate = startDate.plusMonths(1).minusNanos(1);
-
-		List<TransactionJpaEntity> transactionJpaEntities = jpaQueryFactory
-			.select(transactionJpaEntity)
-			.from(transactionJpaEntity)
-			.join(transactionJpaEntity.category, categoryJpaEntity)
+	public List<Transaction> findTransactions(TransactionSearchCriteria criteria) {
+		return jpaQueryFactory
+			.selectFrom(transactionJpaEntity)
 			.join(transactionJpaEntity.creator, memberJpaEntity)
+			.join(transactionJpaEntity.category, categoryJpaEntity)
 			.where(
-				transactionJpaEntity.creator.id.eq(creatorId),
-				transactionJpaEntity.transactionDate.between(startDate, endDate),
+				generateEq(criteria.memberId(), transactionJpaEntity.creator.id::eq),
+				generateEq(criteria.teamId(), transactionJpaEntity.teamId::eq),
+				generateEq(criteria.year(), transactionJpaEntity.transactionDate.year()::eq),
+				generateEq(criteria.month(), transactionJpaEntity.transactionDate.month()::eq),
 				transactionJpaEntity.deletedAt.isNull(),
 				memberJpaEntity.deletedAt.isNull(),
 				categoryJpaEntity.deletedAt.isNull()
 			)
 			.orderBy(transactionJpaEntity.transactionDate.desc())
-			.fetch();
-
-		return transactionJpaEntities.stream().map(TransactionJpaEntity::toModel).toList();
-	}
-
-	@Override
-	public List<Transaction> findByTeamId(Long teamId) {
-		return transactionJpaRepository.findAllByTeamIdAndDeletedAtIsNull(teamId).stream()
-			.map(TransactionJpaEntity::toModel).toList();
+			.fetch()
+			.stream().map(TransactionJpaEntity::toModel).toList();
 	}
 
 	@Override

--- a/src/main/java/com/dalcoomi/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/dalcoomi/transaction/presentation/TransactionController.java
@@ -3,6 +3,7 @@ package com.dalcoomi.transaction.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,10 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dalcoomi.auth.config.AuthMember;
 import com.dalcoomi.transaction.application.TransactionService;
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 import com.dalcoomi.transaction.dto.TransactionsInfo;
 import com.dalcoomi.transaction.dto.request.TransactionRequest;
 import com.dalcoomi.transaction.dto.response.GetMyTransactionResponse;
-import com.dalcoomi.transaction.dto.response.GetMyTransactionsResponse;
+import com.dalcoomi.transaction.dto.response.GetTransactionsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,29 +33,31 @@ public class TransactionController {
 
 	private final TransactionService transactionService;
 
-	@PostMapping("/my")
+	@PostMapping
 	@ResponseStatus(CREATED)
-	public void createMyTransaction(@AuthMember Long memberId, @RequestBody TransactionRequest request) {
+	public void createTransaction(@AuthMember Long memberId, @RequestBody TransactionRequest request) {
 		Transaction transaction = Transaction.from(request);
 
 		transactionService.createTransaction(memberId, request.categoryId(), transaction);
 	}
 
-	@GetMapping("/my")
+	@GetMapping
 	@ResponseStatus(OK)
-	public GetMyTransactionsResponse getMyTransactionsWithYearAndMonth(@AuthMember Long memberId,
-		@RequestParam("year") Integer year, @RequestParam("month") Integer month) {
-		TransactionsInfo transactionsInfo = transactionService.getTransactionsByMemberIdAndYearAndMonth(memberId, year,
-			month);
+	public GetTransactionsResponse getTransactions(@AuthMember Long memberId,
+		@RequestParam("teamId") @Nullable Long teamId, @RequestParam("year") Integer year,
+		@RequestParam("month") Integer month) {
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(memberId, teamId, year, month);
 
-		return GetMyTransactionsResponse.from(transactionsInfo);
+		TransactionsInfo transactionsInfo = transactionService.getTransactions(criteria);
+
+		return GetTransactionsResponse.from(transactionsInfo);
 	}
 
 	@GetMapping("/{transactionId}")
 	@ResponseStatus(OK)
-	public GetMyTransactionResponse getTransactionById(@AuthMember Long memberId,
+	public GetMyTransactionResponse getMyTransaction(@AuthMember Long memberId,
 		@PathVariable("transactionId") Long transactionId) {
-		Transaction transaction = transactionService.getTransactionsById(memberId, transactionId);
+		Transaction transaction = transactionService.getMyTransaction(memberId, transactionId);
 
 		return GetMyTransactionResponse.from(transaction);
 	}

--- a/src/test/java/com/dalcoomi/fixture/TransactionFixture.java
+++ b/src/test/java/com/dalcoomi/fixture/TransactionFixture.java
@@ -26,7 +26,7 @@ public final class TransactionFixture {
 	}
 
 	public static Transaction getTransactionWithExpense2(Member member, Category category) {
-		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 15, 12, 30);
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 11, 12, 30);
 		String content = "점심 식사";
 		Long amount = 15000L;
 
@@ -41,7 +41,7 @@ public final class TransactionFixture {
 	}
 
 	public static Transaction getTransactionWithExpense3(Member member, Category category) {
-		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 30, 18, 0);
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 12, 18, 0);
 		String content = "저녁 식사";
 		Long amount = 20000L;
 
@@ -71,7 +71,7 @@ public final class TransactionFixture {
 	}
 
 	public static Transaction getTeamTransactionWithExpense1(Member member, Long teamId, Category category) {
-		LocalDateTime transactionDate = LocalDateTime.of(2025, 5, 15, 14, 0);
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 15, 14, 0);
 		String content = "5월 식사";
 		Long amount = 22000L;
 
@@ -87,7 +87,7 @@ public final class TransactionFixture {
 	}
 
 	public static Transaction getTeamTransactionWithExpense2(Member member, Long teamId, Category category) {
-		LocalDateTime transactionDate = LocalDateTime.of(2025, 5, 15, 16, 0);
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 15, 16, 0);
 		String content = "5월 식사";
 		Long amount = 20000L;
 
@@ -103,7 +103,7 @@ public final class TransactionFixture {
 	}
 
 	public static Transaction getTeamTransactionWithExpense3(Member member, Long teamId, Category category) {
-		LocalDateTime transactionDate = LocalDateTime.of(2025, 5, 15, 18, 0);
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 15, 18, 0);
 		String content = "5월 식사";
 		Long amount = 32000L;
 

--- a/src/test/java/com/dalcoomi/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/dalcoomi/team/presentation/TeamControllerTest.java
@@ -50,6 +50,7 @@ import com.dalcoomi.team.dto.request.LeaveTeamRequest;
 import com.dalcoomi.team.dto.request.TeamRequest;
 import com.dalcoomi.transaction.application.repository.TransactionRepository;
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Transactional
@@ -508,9 +509,10 @@ class TeamControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		LeaveTeamRequest request = new LeaveTeamRequest(team.getId(), nextLeader.getNickname());
-		String json = objectMapper.writeValueAsString(request);
 
 		// when & then
+		String json = objectMapper.writeValueAsString(request);
+
 		mockMvc.perform(delete("/api/team/leave")
 				.content(json)
 				.contentType(APPLICATION_JSON))
@@ -538,7 +540,6 @@ class TeamControllerTest {
 		teamMemberRepository.save(lastTeamMember);
 
 		Category category = CategoryFixture.getCategory1(lastMember);
-
 		category = categoryRepository.save(category);
 
 		Transaction transaction1 = TransactionFixture.getTeamTransactionWithExpense1(lastMember, team.getId(),
@@ -549,9 +550,7 @@ class TeamControllerTest {
 			category);
 		Transaction transaction4 = TransactionFixture.getTeamTransactionWithExpense4(lastMember, team.getId(),
 			category);
-
 		List<Transaction> transactions = Arrays.asList(transaction1, transaction2, transaction3, transaction4);
-
 		transactionRepository.saveAll(transactions);
 
 		// 인증 설정
@@ -566,9 +565,10 @@ class TeamControllerTest {
 
 		Long teamId = team.getId();
 		LeaveTeamRequest request = new LeaveTeamRequest(teamId, null);
-		String json = objectMapper.writeValueAsString(request);
 
 		// when & then
+		String json = objectMapper.writeValueAsString(request);
+
 		mockMvc.perform(delete("/api/team/leave")
 				.content(json)
 				.contentType(APPLICATION_JSON))
@@ -582,7 +582,9 @@ class TeamControllerTest {
 			.isInstanceOf(NotFoundException.class)
 			.hasMessageContaining(TEAM_NOT_FOUND.getMessage());
 
-		List<Transaction> teamTransactions = transactionRepository.findByTeamId(teamId);
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(lastTeamMember.getId(), teamId, null, null);
+
+		List<Transaction> teamTransactions = transactionRepository.findTransactions(criteria);
 		assertThat(teamTransactions).isEmpty();
 	}
 }

--- a/src/test/java/com/dalcoomi/transaction/presentation/TransactionControllerTest.java
+++ b/src/test/java/com/dalcoomi/transaction/presentation/TransactionControllerTest.java
@@ -35,11 +35,17 @@ import com.dalcoomi.category.application.repository.CategoryRepository;
 import com.dalcoomi.category.domain.Category;
 import com.dalcoomi.fixture.CategoryFixture;
 import com.dalcoomi.fixture.MemberFixture;
+import com.dalcoomi.fixture.TeamFixture;
 import com.dalcoomi.fixture.TransactionFixture;
 import com.dalcoomi.member.application.repository.MemberRepository;
 import com.dalcoomi.member.domain.Member;
+import com.dalcoomi.team.application.repository.TeamMemberRepository;
+import com.dalcoomi.team.application.repository.TeamRepository;
+import com.dalcoomi.team.domain.Team;
+import com.dalcoomi.team.domain.TeamMember;
 import com.dalcoomi.transaction.application.repository.TransactionRepository;
 import com.dalcoomi.transaction.domain.Transaction;
+import com.dalcoomi.transaction.dto.TransactionSearchCriteria;
 import com.dalcoomi.transaction.dto.request.TransactionRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -66,14 +72,20 @@ class TransactionControllerTest {
 	@Autowired
 	private CategoryRepository categoryRepository;
 
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Autowired
+	private TeamMemberRepository teamMemberRepository;
+
 	@Test
 	@DisplayName("통합 테스트 - 개인 거래 내역 저장 성공")
-	void save_my_transactions_success() throws Exception {
+	void save_my_transaction_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -84,27 +96,28 @@ class TransactionControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		Category category = CategoryFixture.getCategory1(member);
-
 		category = categoryRepository.save(category);
 
 		Long amount = 30000L;
 		String content = "앙";
 		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 1, 12, 0);
 
-		TransactionRequest request = new TransactionRequest(amount, content, transactionDate, EXPENSE,
+		TransactionRequest request = new TransactionRequest(null, amount, content, transactionDate, EXPENSE,
 			category.getId());
 
 		// when & then
 		String json = objectMapper.writeValueAsString(request);
 
-		mockMvc.perform(post("/api/transaction/my")
+		mockMvc.perform(post("/api/transaction")
 				.content(json)
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isCreated())
 			.andDo(print());
 
-		List<Transaction> transactions = transactionRepository.findByCreatorIdAndYearAndMonth(member.getId(),
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(member.getId(), null,
 			transactionDate.getYear(), transactionDate.getMonthValue());
+
+		List<Transaction> transactions = transactionRepository.findTransactions(criteria);
 
 		assertThat(transactions.getFirst().getCreator().getId()).isEqualTo(member.getId());
 		assertThat(transactions.getFirst().getAmount()).isEqualTo(amount);
@@ -114,13 +127,19 @@ class TransactionControllerTest {
 	}
 
 	@Test
-	@DisplayName("통합 테스트 - 특정 거래 내역 조회 성공")
-	void get_my_transaction_by_id_success() throws Exception {
+	@DisplayName("통합 테스트 - 그룹 거래 내역 저장 성공")
+	void save_team_transaction_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		Team team = TeamFixture.getTeam1(member);
+		team = teamRepository.save(team);
+
+		TeamMember leaderTeamMember = TeamMember.of(team, member);
+		teamMemberRepository.save(leaderTeamMember);
+
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -131,24 +150,34 @@ class TransactionControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		Category category = CategoryFixture.getCategory1(member);
-
 		category = categoryRepository.save(category);
 
-		Transaction transaction1 = TransactionFixture.getTransactionWithExpense1(member, category);
+		Long amount = 30000L;
+		String content = "앙";
+		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 1, 12, 0);
 
-		transaction1 = transactionRepository.save(transaction1);
+		TransactionRequest request = new TransactionRequest(team.getId(), amount, content, transactionDate, EXPENSE,
+			category.getId());
 
 		// when & then
-		mockMvc.perform(get("/api/transaction/{transactionId}", transaction1.getId())
+		String json = objectMapper.writeValueAsString(request);
+
+		mockMvc.perform(post("/api/transaction")
+				.content(json)
 				.contentType(APPLICATION_JSON))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.transactionId").value(transaction1.getId()))
-			.andExpect(jsonPath("$.amount").value(transaction1.getAmount()))
-			.andExpect(jsonPath("$.content").value(transaction1.getContent()))
-			.andExpect(jsonPath("$.transactionType").value(transaction1.getTransactionType().name()))
-			.andExpect(jsonPath("$.categoryName").value(category.getName()))
-			.andExpect(jsonPath("$.iconUrl").value(category.getIconUrl()))
+			.andExpect(status().isCreated())
 			.andDo(print());
+
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(member.getId(), null,
+			transactionDate.getYear(), transactionDate.getMonthValue());
+
+		List<Transaction> transactions = transactionRepository.findTransactions(criteria);
+
+		assertThat(transactions.getFirst().getCreator().getId()).isEqualTo(member.getId());
+		assertThat(transactions.getFirst().getAmount()).isEqualTo(amount);
+		assertThat(transactions.getFirst().getContent()).isEqualTo(content);
+		assertThat(transactions.getFirst().getTransactionDate()).isEqualTo(transactionDate);
+		assertThat(transactions.getFirst().getTransactionType()).isEqualTo(EXPENSE);
 	}
 
 	@Test
@@ -156,9 +185,15 @@ class TransactionControllerTest {
 	void get_my_transactions_with_year_and_month_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		Team team = TeamFixture.getTeam1(member);
+		team = teamRepository.save(team);
+
+		TeamMember teamMember = TeamMember.of(team, member);
+		teamMemberRepository.save(teamMember);
+
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -169,23 +204,121 @@ class TransactionControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		Category category = CategoryFixture.getCategory1(member);
-
 		category = categoryRepository.save(category);
 
 		Transaction transaction1 = TransactionFixture.getTransactionWithExpense1(member, category);
 		Transaction transaction2 = TransactionFixture.getTransactionWithExpense2(member, category);
 		Transaction transaction3 = TransactionFixture.getTransactionWithExpense3(member, category);
 		Transaction transaction4 = TransactionFixture.getTransactionWithExpense4(member, category);
-
-		List<Transaction> transactions = Arrays.asList(transaction1, transaction2, transaction3, transaction4);
-
+		Transaction transaction5 = TransactionFixture.getTeamTransactionWithExpense1(member, team.getId(), category);
+		Transaction transaction6 = TransactionFixture.getTeamTransactionWithExpense2(member, team.getId(), category);
+		Transaction transaction7 = TransactionFixture.getTeamTransactionWithExpense3(member, team.getId(), category);
+		Transaction transaction8 = TransactionFixture.getTeamTransactionWithExpense4(member, team.getId(), category);
+		List<Transaction> transactions = Arrays.asList(transaction1, transaction2, transaction3, transaction4,
+			transaction5, transaction6, transaction7, transaction8);
 		transactionRepository.saveAll(transactions);
 
 		int year = 2025;
 		int month = 3;
 
 		// when & then
-		mockMvc.perform(get("/api/transaction/my")
+		mockMvc.perform(get("/api/transaction")
+				.param("year", String.valueOf(year))
+				.param("month", String.valueOf(month))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.income").value(0))
+			.andExpect(jsonPath("$.expense").value(
+				transaction1.getAmount() + transaction2.getAmount() + transaction3.getAmount()
+					+ transaction5.getAmount() + transaction6.getAmount() + transaction7.getAmount()))
+			.andExpect(jsonPath("$.total").value(
+				-(transaction1.getAmount() + transaction2.getAmount() + transaction3.getAmount()
+					+ transaction5.getAmount() + transaction6.getAmount() + transaction7.getAmount())))
+			.andExpect(jsonPath("$.transactions").isArray())
+			.andExpect(jsonPath("$.transactions.length()").value(6))
+			.andExpect(jsonPath("$.transactions[0].content").value(transaction7.getContent()))
+			.andExpect(jsonPath("$.transactions[1].content").value(transaction6.getContent()))
+			.andExpect(jsonPath("$.transactions[2].content").value(transaction5.getContent()))
+			.andExpect(jsonPath("$.transactions[0].amount").value(transaction7.getAmount()))
+			.andExpect(jsonPath("$.transactions[0].transactionType").value(transaction7.getTransactionType().name()))
+			.andExpect(jsonPath("$.transactions[0].categoryName").value(category.getName()))
+			.andExpect(jsonPath("$.transactions[0].creatorNickname").value(member.getNickname()))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 데이터가 없는 달의 개인 거래 내역 조회 시 빈 배열 조회 성공")
+	void get_my_transactions_empty_month_success() throws Exception {
+		// given
+		Member member = MemberFixture.getMember1();
+		member = memberRepository.save(member);
+
+		// 인증 설정
+		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
+			member.getId().toString(),
+			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(memberUserDetails, null,
+			authoritiesMapper.mapAuthorities(memberUserDetails.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		int year = 2024;
+		int month = 12;
+
+		// when & then
+		mockMvc.perform(get("/api/transaction")
+				.param("year", String.valueOf(year))
+				.param("month", String.valueOf(month))
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.income").value(0))
+			.andExpect(jsonPath("$.expense").value(0))
+			.andExpect(jsonPath("$.total").value(0))
+			.andExpect(jsonPath("$.transactions").isArray())
+			.andExpect(jsonPath("$.transactions.length()").value(0))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 그룹 거래 내역 리스트 조회 성공")
+	void get_team_transactions_success() throws Exception {
+		// given
+		Member member = MemberFixture.getMember1();
+		member = memberRepository.save(member);
+
+		Team team = TeamFixture.getTeam1(member);
+		team = teamRepository.save(team);
+
+		TeamMember teamMember = TeamMember.of(team, member);
+		teamMemberRepository.save(teamMember);
+
+		// 인증 설정
+		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
+			member.getId().toString(),
+			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(memberUserDetails, null,
+			authoritiesMapper.mapAuthorities(memberUserDetails.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Category category = CategoryFixture.getCategory1(member);
+		category = categoryRepository.save(category);
+
+		Transaction transaction1 = TransactionFixture.getTeamTransactionWithExpense1(member, team.getId(), category);
+		Transaction transaction2 = TransactionFixture.getTeamTransactionWithExpense2(member, team.getId(), category);
+		Transaction transaction3 = TransactionFixture.getTeamTransactionWithExpense3(member, team.getId(), category);
+		Transaction transaction4 = TransactionFixture.getTeamTransactionWithExpense4(member, team.getId(), category);
+		List<Transaction> transactions = Arrays.asList(transaction1, transaction2, transaction3, transaction4);
+		transactionRepository.saveAll(transactions);
+
+		int year = 2025;
+		int month = 3;
+
+		// when & then
+		mockMvc.perform(get("/api/transaction")
+				.param("teamId", String.valueOf(team.getId()))
 				.param("year", String.valueOf(year))
 				.param("month", String.valueOf(month))
 				.contentType(APPLICATION_JSON))
@@ -208,13 +341,19 @@ class TransactionControllerTest {
 	}
 
 	@Test
-	@DisplayName("통합 테스트 - 데이터가 없는 달의 개인 거래 내역 조회 시 빈 배열 조회 성공")
-	void get_my_transactions_empty_month_success() throws Exception {
+	@DisplayName("통합 테스트 - 데이터가 없는 달의 그룹 거래 내역 조회 시 빈 배열 조회 성공")
+	void get_team_transactions_empty_month_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		Team team = TeamFixture.getTeam1(member);
+		team = teamRepository.save(team);
+
+		TeamMember teamMember = TeamMember.of(team, member);
+		teamMemberRepository.save(teamMember);
+
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -228,7 +367,8 @@ class TransactionControllerTest {
 		int month = 12;
 
 		// when & then
-		mockMvc.perform(get("/api/transaction/my")
+		mockMvc.perform(get("/api/transaction")
+				.param("teamId", String.valueOf(team.getId()))
 				.param("year", String.valueOf(year))
 				.param("month", String.valueOf(month))
 				.contentType(APPLICATION_JSON))
@@ -242,13 +382,13 @@ class TransactionControllerTest {
 	}
 
 	@Test
-	@DisplayName("통합 테스트 - 특정 거래 내역 수정 성공")
-	void update_transaction_success() throws Exception {
+	@DisplayName("통합 테스트 - 특정 거래 내역 조회 성공")
+	void get_my_transaction_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -259,18 +399,51 @@ class TransactionControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		Category category = CategoryFixture.getCategory1(member);
-
 		category = categoryRepository.save(category);
 
 		Transaction transaction1 = TransactionFixture.getTransactionWithExpense1(member, category);
+		transaction1 = transactionRepository.save(transaction1);
 
+		// when & then
+		mockMvc.perform(get("/api/transaction/{transactionId}", transaction1.getId())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.transactionId").value(transaction1.getId()))
+			.andExpect(jsonPath("$.amount").value(transaction1.getAmount()))
+			.andExpect(jsonPath("$.content").value(transaction1.getContent()))
+			.andExpect(jsonPath("$.transactionType").value(transaction1.getTransactionType().name()))
+			.andExpect(jsonPath("$.categoryName").value(category.getName()))
+			.andExpect(jsonPath("$.iconUrl").value(category.getIconUrl()))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 특정 거래 내역 수정 성공")
+	void update_transaction_success() throws Exception {
+		// given
+		Member member = MemberFixture.getMember1();
+		member = memberRepository.save(member);
+
+		// 인증 설정
+		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
+			member.getId().toString(),
+			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(memberUserDetails, null,
+			authoritiesMapper.mapAuthorities(memberUserDetails.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Category category = CategoryFixture.getCategory1(member);
+		category = categoryRepository.save(category);
+
+		Transaction transaction1 = TransactionFixture.getTransactionWithExpense1(member, category);
 		transaction1 = transactionRepository.save(transaction1);
 
 		Long amount = 20000L;
 		String content = "엉";
 		LocalDateTime transactionDate = LocalDateTime.of(2025, 3, 2, 12, 0);
-
-		TransactionRequest request = new TransactionRequest(amount, content, transactionDate, EXPENSE,
+		TransactionRequest request = new TransactionRequest(null, amount, content, transactionDate, EXPENSE,
 			category.getId());
 
 		// when & then
@@ -296,9 +469,9 @@ class TransactionControllerTest {
 	void delete_transaction_success() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
-
 		member = memberRepository.save(member);
 
+		// 인증 설정
 		CustomUserDetails memberUserDetails = new CustomUserDetails(member.getId(),
 			member.getId().toString(),
 			authoritiesMapper.mapAuthorities(List.of(new SimpleGrantedAuthority("ROLE_USER"))));
@@ -309,11 +482,9 @@ class TransactionControllerTest {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		Category category = CategoryFixture.getCategory1(member);
-
 		category = categoryRepository.save(category);
 
 		Transaction transaction1 = TransactionFixture.getTransactionWithExpense1(member, category);
-
 		transaction1 = transactionRepository.save(transaction1);
 
 		// when & then


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 회원 조회 기능 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #14 

**✅ Tasks**

- 그룹 거래 내역 등록 API 구현
  - 기존 내 거래 내역 등록 API랑 통합
  - validate 메서드로 해당 그룹의 회원인지 검증 후 거래 내역 저장
- 그룹 거래 내역 리스트 조회 API 구현
  - 기존 내 거래 내역 리스트 조회 API랑 통합
  - validate 메서드로 해당 그룹의 회원인지 검증 후 거래 내역 조회
- 위 API와 관련한 메서드명, 변수명 좀 더 직관적으로 수정

**🙋🏻 More**

- 참고 내용
