### PR TITLE
[#21]fix: 그룹 정보 조회 시 초대 코드 없던 버그 해결

### DIFF
--- a/src/main/java/com/dalcoomi/team/dto/response/GetTeamResponse.java
+++ b/src/main/java/com/dalcoomi/team/dto/response/GetTeamResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 public record GetTeamResponse(
 	Long teamId,
 	String title,
+	String invitationCode,
 	Integer memberLimit,
 	String purpose,
 	String leaderNickname,
@@ -23,6 +24,7 @@ public record GetTeamResponse(
 		return GetTeamResponse.builder()
 			.teamId(teamInfo.team().getId())
 			.title(teamInfo.team().getTitle())
+			.invitationCode(teamInfo.team().getInvitationCode())
 			.memberLimit(teamInfo.team().getMemberLimit())
 			.purpose(teamInfo.team().getPurpose())
 			.leaderNickname(teamInfo.team().getLeader().getNickname())


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 회원 조회 기능 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #21 

**✅ Tasks**

- 그룹 정보 조회 시 응답에 초대 코드 추가

**🙋🏻 More**

- 참고 내용
