### PR TITLE
[#62]feat: 그룹 거래 내역 조회 시 카테고리, 작성자 필터링 기능 구현

### DIFF
--- a/src/main/java/com/dalcoomi/transaction/dto/TransactionSearchCriteria.java
+++ b/src/main/java/com/dalcoomi/transaction/dto/TransactionSearchCriteria.java
@@ -10,16 +10,21 @@ public record TransactionSearchCriteria(
 	Long memberId,
 	Long teamId,
 	Integer year,
-	Integer month
+	Integer month,
+	String categoryName,
+	String creatorNickname
 ) {
 
-	public static TransactionSearchCriteria of(Long memberId, @Nullable Long teamId, Integer year, Integer month) {
+	public static TransactionSearchCriteria of(Long memberId, @Nullable Long teamId, Integer year, Integer month,
+		String categoryName, String creatorNickname) {
 		return TransactionSearchCriteria.builder()
 			.requesterId(memberId)
 			.memberId(teamId == null ? memberId : null)
 			.teamId(teamId)
 			.year(year)
 			.month(month)
+			.categoryName(categoryName)
+			.creatorNickname(creatorNickname)
 			.build();
 	}
 }

--- a/src/main/java/com/dalcoomi/transaction/infrastructure/TransactionRepositoryImpl.java
+++ b/src/main/java/com/dalcoomi/transaction/infrastructure/TransactionRepositoryImpl.java
@@ -57,6 +57,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
 				generateEq(criteria.memberId(), transactionJpaEntity.creator.id::eq),
 				generateEq(criteria.year(), transactionJpaEntity.transactionDate.year()::eq),
 				generateEq(criteria.month(), transactionJpaEntity.transactionDate.month()::eq),
+				generateEq(criteria.categoryName(), transactionJpaEntity.category.name::eq),
+				generateEq(criteria.creatorNickname(), transactionJpaEntity.creator.nickname::eq),
 				transactionJpaEntity.deletedAt.isNull(),
 				memberJpaEntity.deletedAt.isNull(),
 				categoryJpaEntity.deletedAt.isNull()

--- a/src/main/java/com/dalcoomi/transaction/presentation/TransactionController.java
+++ b/src/main/java/com/dalcoomi/transaction/presentation/TransactionController.java
@@ -94,8 +94,11 @@ public class TransactionController {
 	@GetMapping
 	@ResponseStatus(OK)
 	public GetTransactionsResponse get(@AuthMember Long memberId, @RequestParam("teamId") @Nullable Long teamId,
-		@RequestParam("year") Integer year, @RequestParam("month") Integer month) {
-		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(memberId, teamId, year, month);
+		@RequestParam("year") Integer year, @RequestParam("month") Integer month,
+		@RequestParam("categoryName") @Nullable String categoryName,
+		@RequestParam("creatorNickname") @Nullable String creatorNickname) {
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(memberId, teamId, year, month, categoryName,
+			creatorNickname);
 
 		TransactionsInfo transactionsInfo = transactionService.get(criteria);
 

--- a/src/test/java/com/dalcoomi/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/dalcoomi/team/presentation/TeamControllerTest.java
@@ -575,7 +575,8 @@ class TeamControllerTest {
 			.isInstanceOf(NotFoundException.class)
 			.hasMessageContaining(TEAM_NOT_FOUND.getMessage());
 
-		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(lastTeamMember.getId(), teamId, null, null);
+		TransactionSearchCriteria criteria = TransactionSearchCriteria.of(lastTeamMember.getId(), teamId, null, null,
+			null, null);
 
 		List<Transaction> teamTransactions = transactionRepository.findTransactions(criteria);
 		assertThat(teamTransactions).isEmpty();


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 회원 조회 기능 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**
- close #62 

**✅ Tasks**
- 그룹 거래 내역 조회 시 필터링 기능 구현
  - 조회 API 요청 시 ``categoryName``, ``creatorNickname`` 파라미터 추가
  - 카테고리명, 작성자 닉네임 필터링 가능

**🙋🏻 More**
- 참고 내용