### PR TITLE
[#75]feat: 프로필 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,4 +203,5 @@ dependencies {
 
     // 이미지 메타데이터 관련 라이브러리
     implementation 'com.drewnoakes:metadata-extractor:2.19.0'
+    implementation 'org.apache.commons:commons-imaging:1.0.0-alpha6'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -194,4 +194,13 @@ dependencies {
     // Test Container
     testImplementation "org.testcontainers:testcontainers:1.20.4"
     testImplementation "org.testcontainers:junit-jupiter:1.20.4"
+
+    // AWS S3 SDK
+    implementation 'software.amazon.awssdk:s3:2.32.29'
+
+    // Thumbnailator - 이미지 리사이징과 포맷 변환
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
+    // 이미지 메타데이터 관련 라이브러리
+    implementation 'com.drewnoakes:metadata-extractor:2.19.0'
 }

--- a/src/main/java/com/dalcoomi/common/error/model/ErrorMessage.java
+++ b/src/main/java/com/dalcoomi/common/error/model/ErrorMessage.java
@@ -33,6 +33,7 @@ public enum ErrorMessage {
 
 	MEMBER_NOT_FOUND("존재하지 않는 회원입니다."),
 	MEMBER_CONFLICT("이미 존재하는 회원입니다."),
+	MEMBER_NICKNAME_CONFLICT("이미 존재하는 닉네임입니다."),
 	MEMBER_INVALID_SOCIAL_ID("유효하지 않는 소셜 ID 입니다."),
 	MEMBER_INVALID_EMAIL("유효하지 않는 EMAIL 입니다."),
 	MEMBER_INVALID_NAME("유효하지 않는 이름입니다."),

--- a/src/main/java/com/dalcoomi/image/application/S3Service.java
+++ b/src/main/java/com/dalcoomi/image/application/S3Service.java
@@ -1,0 +1,182 @@
+package com.dalcoomi.image.application;
+
+import static com.dalcoomi.common.error.model.ErrorMessage.IMAGE_NOT_FOUND;
+import static com.dalcoomi.common.error.model.ErrorMessage.IMAGE_NOT_SUPPORT;
+import static com.dalcoomi.image.constant.ImageConstants.IMAGE_QUALITY;
+import static com.dalcoomi.image.constant.ImageConstants.MAX_HEIGHT;
+import static com.dalcoomi.image.constant.ImageConstants.MAX_WIDTH;
+import static com.dalcoomi.image.constant.ImageConstants.S3_PROFILE_IMAGE_PATH;
+import static com.drew.metadata.exif.ExifDirectoryBase.TAG_ORIENTATION;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.coobird.thumbnailator.Thumbnails;
+
+import com.dalcoomi.common.error.exception.ImageException;
+import com.dalcoomi.image.infrastructure.S3Adapter;
+import com.dalcoomi.member.dto.AvatarInfo;
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.exif.ExifIFD0Directory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	protected static final List<String> SUPPORTED_FORMATS = Arrays.asList("jpg", "jpeg", "png", "svg");
+
+	private final S3Adapter s3Adapter;
+
+	@Value("${aws.s3.image-base-url}")
+	private String imageBaseUrl;
+
+	public String uploadImage(String defaultImage, String folderPath, @Nullable MultipartFile image) {
+		if (image == null) {
+			return defaultImage;
+		}
+
+		String extension = validateImageFormat(image);
+
+		try {
+			StopWatch sw = new StopWatch();
+			sw.start();
+			byte[] processedImage = processImage(image, extension);
+			sw.stop();
+
+			log.debug("========== 이미지 처리 시간: {}ms ==========", sw.getTotalTimeMillis());
+
+			return s3Adapter.uploadFile(processedImage, folderPath, extension);
+		} catch (Exception e) {
+			return defaultImage;
+		}
+	}
+
+	public void deleteImage(String imageUrl) {
+		try {
+			String s3Key = imageUrl.replace(imageBaseUrl, "");
+
+			s3Adapter.deleteFile(s3Key);
+		} catch (Exception e) {
+			log.error("이미지 삭제 실패: {}", imageUrl, e);
+		}
+	}
+
+	public String handleAvatar(boolean removeAvatar, AvatarInfo avatarInfo, @Nullable MultipartFile multipartFile) {
+		String currentAvatarUrl = avatarInfo.member().getProfileImageUrl();
+
+		// 프사 등록 or 수정
+		if (!removeAvatar && multipartFile != null) {
+			// 수정 시
+			if (!avatarInfo.defaultImage()) {
+				// s3에서 현재 url 삭제
+				deleteImage(currentAvatarUrl);
+			}
+
+			// s3에 저장 후 링크 리턴
+			return uploadImage(currentAvatarUrl, S3_PROFILE_IMAGE_PATH, multipartFile);
+		}
+
+		// 프사 삭제
+		if (removeAvatar && !avatarInfo.defaultImage()) {
+			deleteImage(currentAvatarUrl);
+
+			return null;
+		} else {
+			return currentAvatarUrl;
+		}
+	}
+
+	private String validateImageFormat(MultipartFile image) {
+		String originalFilename = image.getOriginalFilename();
+
+		if (originalFilename == null) {
+			throw new ImageException(IMAGE_NOT_FOUND);
+		}
+
+		String extension = getExtension(originalFilename).toLowerCase();
+
+		if (!SUPPORTED_FORMATS.contains(extension)) {
+			throw new ImageException(IMAGE_NOT_SUPPORT);
+		}
+
+		return extension;
+	}
+
+	private String getExtension(String filename) {
+		int lastDotIndex = filename.lastIndexOf('.');
+
+		if (lastDotIndex == -1) {
+			throw new ImageException(IMAGE_NOT_FOUND);
+		}
+
+		return filename.substring(lastDotIndex + 1);
+	}
+
+	private byte[] processImage(MultipartFile image, String extension) throws IOException {
+		if ("svg".equals(extension)) {
+			return image.getBytes();
+		}
+
+		// 원본 이미지 읽기
+		BufferedImage originalImage = ImageIO.read(image.getInputStream());
+
+		// 리사이징
+		BufferedImage resizedImage = Thumbnails.of(originalImage)
+			.size(MAX_WIDTH, MAX_HEIGHT)
+			.keepAspectRatio(true)
+			.asBufferedImage();
+
+		// 리사이즈된 이미지를 회전
+		resizedImage = rotateImageIfRequired(resizedImage, image);
+
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		Thumbnails.of(resizedImage)
+			.scale(1.0)  // 크기는 그대로
+			.outputQuality(IMAGE_QUALITY)
+			.outputFormat(extension)
+			.toOutputStream(outputStream);
+
+		return outputStream.toByteArray();
+	}
+
+	private BufferedImage rotateImageIfRequired(BufferedImage image, MultipartFile multipartFile) throws IOException {
+		try {
+			Metadata metadata = ImageMetadataReader.readMetadata(multipartFile.getInputStream());
+			Directory directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
+
+			if (directory != null && directory.containsTag(TAG_ORIENTATION)) {
+				int orientation = directory.getInt(TAG_ORIENTATION);
+
+				return switch (orientation) {
+					case 3 -> Thumbnails.of(image).scale(1.0).rotate(180).asBufferedImage();
+					case 6 -> Thumbnails.of(image).scale(1.0).rotate(90).asBufferedImage();
+					case 8 -> Thumbnails.of(image).scale(1.0).rotate(270).asBufferedImage();
+					default -> image;
+				};
+			}
+		} catch (ImageProcessingException | MetadataException e) {
+			log.warn("이미지 방향 정보 읽기 실패", e);
+		}
+
+		return image;
+	}
+}

--- a/src/main/java/com/dalcoomi/image/config/S3Config.java
+++ b/src/main/java/com/dalcoomi/image/config/S3Config.java
@@ -1,0 +1,36 @@
+package com.dalcoomi.image.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+	@Value("${aws.region}")
+	private String awsRegion;
+
+	@Value("${aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Bean
+	public S3Client s3Client() {
+		AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+			AwsBasicCredentials.create(accessKey, secretKey)
+		);
+
+		return S3Client.builder()
+			.region(Region.of(awsRegion))
+			.credentialsProvider(credentialsProvider)
+			.build();
+	}
+}

--- a/src/main/java/com/dalcoomi/image/constant/ImageConstants.java
+++ b/src/main/java/com/dalcoomi/image/constant/ImageConstants.java
@@ -1,4 +1,4 @@
-package com.dalcoomi.common.constant;
+package com.dalcoomi.image.constant;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -6,8 +6,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageConstants {
 
+	public static final int MAX_WIDTH = 1200;
+	public static final int MAX_HEIGHT = 1200;
+	public static final double IMAGE_QUALITY = 0.9;
+
 	public static final String DEFAULT_PROFILE_IMAGE_1 = "https://dalcoomi.s3.ap-northeast-2.amazonaws.com/profile/%EA%B8%B0%EB%B3%B8_%ED%94%84%EB%A1%9C%ED%95%84_%EC%82%AC%EC%A7%84_1.png";
 	public static final String DEFAULT_PROFILE_IMAGE_2 = "https://dalcoomi.s3.ap-northeast-2.amazonaws.com/profile/%EA%B8%B0%EB%B3%B8_%ED%94%84%EB%A1%9C%ED%95%84_%EC%82%AC%EC%A7%84_2.png";
 	public static final String DEFAULT_PROFILE_IMAGE_3 = "https://dalcoomi.s3.ap-northeast-2.amazonaws.com/profile/%EA%B8%B0%EB%B3%B8_%ED%94%84%EB%A1%9C%ED%95%84_%EC%82%AC%EC%A7%84_3.png";
 	public static final String DEFAULT_PROFILE_IMAGE_4 = "https://dalcoomi.s3.ap-northeast-2.amazonaws.com/profile/%EA%B8%B0%EB%B3%B8_%ED%94%84%EB%A1%9C%ED%95%84_%EC%82%AC%EC%A7%84_4.png";
+
+	public static final String S3_PROFILE_IMAGE_PATH = "profile";
+
+	public static final String S3_CATEGORY_ADMIN_IMAGE_PATH = "category/admin";
+	public static final String S3_CATEGORY_MEMBER_IMAGE_PATH = "category/member";
 }

--- a/src/main/java/com/dalcoomi/image/infrastructure/S3Adapter.java
+++ b/src/main/java/com/dalcoomi/image/infrastructure/S3Adapter.java
@@ -1,0 +1,62 @@
+package com.dalcoomi.image.infrastructure;
+
+import static com.dalcoomi.common.error.model.ErrorMessage.S3_DELETE_ERROR;
+import static com.dalcoomi.common.error.model.ErrorMessage.S3_UPLOAD_ERROR;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.dalcoomi.common.error.exception.ImageException;
+
+import io.hypersistence.tsid.TSID;
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Component
+@RequiredArgsConstructor
+public class S3Adapter {
+
+	private final S3Client s3Client;
+
+	@Value("${aws.s3.bucket-name}")
+	private String bucketName;
+
+	@Value("${aws.s3.image-base-url}")
+	private String imageBaseUrl;
+
+	public String uploadFile(byte[] fileData, String folderPath, String extension) {
+		String fileName = TSID.Factory.getTsid() + "." + extension;
+		String s3Key = folderPath + "/" + fileName;
+
+		try {
+			PutObjectRequest request = PutObjectRequest.builder()
+				.bucket(bucketName)
+				.key(s3Key)
+				.contentType("image/" + extension)
+				.build();
+
+			s3Client.putObject(request, RequestBody.fromBytes(fileData));
+
+			return imageBaseUrl + s3Key;
+		} catch (S3Exception e) {
+			throw new ImageException(S3_UPLOAD_ERROR, e);
+		}
+	}
+
+	public void deleteFile(String s3Key) {
+		try {
+			DeleteObjectRequest request = DeleteObjectRequest.builder()
+				.bucket(bucketName)
+				.key(s3Key)
+				.build();
+
+			s3Client.deleteObject(request);
+		} catch (S3Exception e) {
+			throw new ImageException(S3_DELETE_ERROR, e);
+		}
+	}
+}

--- a/src/main/java/com/dalcoomi/member/application/MemberService.java
+++ b/src/main/java/com/dalcoomi/member/application/MemberService.java
@@ -5,6 +5,7 @@ import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_
 import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_3;
 import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_4;
 import static com.dalcoomi.common.error.model.ErrorMessage.MEMBER_CONFLICT;
+import static com.dalcoomi.common.error.model.ErrorMessage.MEMBER_NICKNAME_CONFLICT;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
@@ -99,18 +100,18 @@ public class MemberService {
 			.build();
 	}
 
-	private String getRandomDefaultProfileImage() {
-		String[] defaultImages = {
-			DEFAULT_PROFILE_IMAGE_1,
-			DEFAULT_PROFILE_IMAGE_2,
-			DEFAULT_PROFILE_IMAGE_3,
-			DEFAULT_PROFILE_IMAGE_4
-		};
+	@Transactional
+	public void updateProfile(Long memberId, MemberInfo memberInfo) {
+		Member member = memberRepository.findById(memberId);
 
-		Random random = new SecureRandom();
-		int randomIndex = random.nextInt(defaultImages.length);
+		if (!member.getNickname().equals(memberInfo.nickname()) && memberRepository.existsByNickname(
+			memberInfo.nickname())) {
+			throw new ConflictException(MEMBER_NICKNAME_CONFLICT);
+		}
 
-		return defaultImages[randomIndex];
+		member.updateProfile(memberInfo.name(), memberInfo.nickname(), memberInfo.birthday(), memberInfo.gender());
+
+		memberRepository.save(member);
 	}
 
 	@Transactional
@@ -179,5 +180,19 @@ public class MemberService {
 			.build();
 
 		withdrawalRepository.save(withdrawal);
+	}
+
+	private String getRandomDefaultProfileImage() {
+		String[] defaultImages = {
+			DEFAULT_PROFILE_IMAGE_1,
+			DEFAULT_PROFILE_IMAGE_2,
+			DEFAULT_PROFILE_IMAGE_3,
+			DEFAULT_PROFILE_IMAGE_4
+		};
+
+		Random random = new SecureRandom();
+		int randomIndex = random.nextInt(defaultImages.length);
+
+		return defaultImages[randomIndex];
 	}
 }

--- a/src/main/java/com/dalcoomi/member/application/MemberService.java
+++ b/src/main/java/com/dalcoomi/member/application/MemberService.java
@@ -1,11 +1,11 @@
 package com.dalcoomi.member.application;
 
-import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_1;
-import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_2;
-import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_3;
-import static com.dalcoomi.common.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_4;
 import static com.dalcoomi.common.error.model.ErrorMessage.MEMBER_CONFLICT;
 import static com.dalcoomi.common.error.model.ErrorMessage.MEMBER_NICKNAME_CONFLICT;
+import static com.dalcoomi.image.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_1;
+import static com.dalcoomi.image.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_2;
+import static com.dalcoomi.image.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_3;
+import static com.dalcoomi.image.constant.ImageConstants.DEFAULT_PROFILE_IMAGE_4;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,7 @@ import com.dalcoomi.member.domain.Member;
 import com.dalcoomi.member.domain.SocialConnection;
 import com.dalcoomi.member.domain.Withdrawal;
 import com.dalcoomi.member.domain.WithdrawalType;
+import com.dalcoomi.member.dto.AvatarInfo;
 import com.dalcoomi.member.dto.MemberInfo;
 import com.dalcoomi.team.application.repository.TeamMemberRepository;
 import com.dalcoomi.team.application.repository.TeamRepository;
@@ -100,18 +102,48 @@ public class MemberService {
 			.build();
 	}
 
+	@Transactional(readOnly = true)
+	public AvatarInfo getAvatarInfo(Long memberId) {
+		Member member = memberRepository.findById(memberId);
+		boolean defaultImage = validateDefaultProfileImage(member.getProfileImageUrl());
+
+		return AvatarInfo.builder()
+			.member(member)
+			.defaultImage(defaultImage)
+			.build();
+	}
+
 	@Transactional
-	public void updateProfile(Long memberId, MemberInfo memberInfo) {
+	public String updateAvatar(Member member, @Nullable String newAvatarUrl) {
+		if (newAvatarUrl == null) {
+			newAvatarUrl = getRandomDefaultProfileImage();
+		}
+
+		member.updateProfileImageUrl(newAvatarUrl);
+
+		memberRepository.save(member);
+
+		return newAvatarUrl;
+	}
+
+	@Transactional
+	public MemberInfo updateProfile(Long memberId, MemberInfo memberInfo) {
 		Member member = memberRepository.findById(memberId);
 
-		if (!member.getNickname().equals(memberInfo.nickname()) && memberRepository.existsByNickname(
-			memberInfo.nickname())) {
+		if (memberRepository.existsByNickname(memberInfo.nickname())) {
 			throw new ConflictException(MEMBER_NICKNAME_CONFLICT);
 		}
 
 		member.updateProfile(memberInfo.name(), memberInfo.nickname(), memberInfo.birthday(), memberInfo.gender());
 
-		memberRepository.save(member);
+		member = memberRepository.save(member);
+
+		return MemberInfo.builder()
+			.name(member.getName())
+			.nickname(member.getNickname())
+			.birthday(member.getBirthday())
+			.gender(member.getGender())
+			.build();
 	}
 
 	@Transactional
@@ -194,5 +226,22 @@ public class MemberService {
 		int randomIndex = random.nextInt(defaultImages.length);
 
 		return defaultImages[randomIndex];
+	}
+
+	private boolean validateDefaultProfileImage(String avatarUrl) {
+		String[] defaultImages = {
+			DEFAULT_PROFILE_IMAGE_1,
+			DEFAULT_PROFILE_IMAGE_2,
+			DEFAULT_PROFILE_IMAGE_3,
+			DEFAULT_PROFILE_IMAGE_4
+		};
+
+		for (String defaultImage : defaultImages) {
+			if (avatarUrl.equals(defaultImage)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/main/java/com/dalcoomi/member/application/repository/MemberRepository.java
+++ b/src/main/java/com/dalcoomi/member/application/repository/MemberRepository.java
@@ -8,6 +8,8 @@ public interface MemberRepository {
 
 	Member save(Member member);
 
+	boolean existsByNickname(String nickname);
+
 	Member findById(Long memberId);
 
 	List<Member> findByIds(List<Long> memberIds);

--- a/src/main/java/com/dalcoomi/member/domain/Member.java
+++ b/src/main/java/com/dalcoomi/member/domain/Member.java
@@ -26,13 +26,13 @@ public class Member {
 
 	private final Long id;
 	private final String email;
-	private final String name;
-	private final String nickname;
-	private final LocalDate birthday;
-	private final String gender;
-	private final String profileImageUrl;
 	private final Boolean serviceAgreement;
 	private final Boolean collectionAgreement;
+	private String name;
+	private String nickname;
+	private LocalDate birthday;
+	private String gender;
+	private String profileImageUrl;
 	private LocalDateTime deletedAt;
 
 	@Builder
@@ -48,6 +48,17 @@ public class Member {
 		this.serviceAgreement = requireNonNull(serviceAgreement);
 		this.collectionAgreement = requireNonNull(collectionAgreement);
 		this.deletedAt = deletedAt;
+	}
+
+	public void updateProfile(String name, String nickname, LocalDate birthday, String gender) {
+		this.name = validateName(name);
+		this.nickname = validateNickname(nickname);
+		this.birthday = birthday;
+		this.gender = validateGender(gender);
+	}
+
+	public void updateProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = validateProfileImageUrl(profileImageUrl);
 	}
 
 	public void softDelete() {

--- a/src/main/java/com/dalcoomi/member/dto/AvatarInfo.java
+++ b/src/main/java/com/dalcoomi/member/dto/AvatarInfo.java
@@ -1,0 +1,13 @@
+package com.dalcoomi.member.dto;
+
+import com.dalcoomi.member.domain.Member;
+
+import lombok.Builder;
+
+@Builder
+public record AvatarInfo(
+	Member member,
+	boolean defaultImage
+) {
+
+}

--- a/src/main/java/com/dalcoomi/member/dto/request/UpdateAvatarRequest.java
+++ b/src/main/java/com/dalcoomi/member/dto/request/UpdateAvatarRequest.java
@@ -1,0 +1,14 @@
+package com.dalcoomi.member.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateAvatarRequest(
+	@NotNull(message = "프로필 사진 삭제 여부는 필수입니다.")
+	Boolean removeAvatar,
+
+	MultipartFile profileImage
+) {
+
+}

--- a/src/main/java/com/dalcoomi/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/dalcoomi/member/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,27 @@
+package com.dalcoomi.member.dto.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateProfileRequest(
+	@NotBlank(message = "이름은 필수입니다.")
+	@Size(min = 2, max = 30, message = "이름은 2~30자 입니다.")
+	String name,
+
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(max = 15, message = "닉네임은 15자 이하여야 합니다.")
+	@Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자, 언더스코어만 사용 가능합니다.")
+	String nickname,
+
+	@Past(message = "생년월일은 과거 날짜여야 합니다.")
+	LocalDate birthday,
+
+	@Size(max = 10, message = "성별은 최대 2자입니다.")
+	String gender
+) {
+
+}

--- a/src/main/java/com/dalcoomi/member/dto/response/UpdateProfileResponse.java
+++ b/src/main/java/com/dalcoomi/member/dto/response/UpdateProfileResponse.java
@@ -1,0 +1,25 @@
+package com.dalcoomi.member.dto.response;
+
+import java.time.LocalDate;
+
+import com.dalcoomi.member.dto.MemberInfo;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateProfileResponse(
+	String name,
+	String nickname,
+	LocalDate birthday,
+	String gender
+) {
+
+	public static UpdateProfileResponse from(MemberInfo memberInfo) {
+		return UpdateProfileResponse.builder()
+			.name(memberInfo.name())
+			.nickname(memberInfo.nickname())
+			.birthday(memberInfo.birthday())
+			.gender(memberInfo.gender())
+			.build();
+	}
+}

--- a/src/main/java/com/dalcoomi/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/com/dalcoomi/member/infrastructure/MemberJpaRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
 
+	boolean existsByNickname(String nickname);
+
 	Optional<MemberJpaEntity> findByIdAndDeletedAtIsNull(Long memberId);
 
 	List<MemberJpaEntity> findAllByIdInAndDeletedAtIsNull(List<Long> memberIds);
 
 	Optional<MemberJpaEntity> findByNicknameAndDeletedAtIsNull(String nextLeaderNickname);
+
 }

--- a/src/main/java/com/dalcoomi/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/dalcoomi/member/infrastructure/MemberRepositoryImpl.java
@@ -26,6 +26,11 @@ public class MemberRepositoryImpl implements MemberRepository {
 	}
 
 	@Override
+	public boolean existsByNickname(String nickname) {
+		return memberJpaRepository.existsByNickname(nickname);
+	}
+
+	@Override
 	public Member findById(Long memberId) {
 		return memberJpaRepository.findByIdAndDeletedAtIsNull(memberId)
 			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND)).toModel();

--- a/src/main/java/com/dalcoomi/member/presentation/MemberController.java
+++ b/src/main/java/com/dalcoomi/member/presentation/MemberController.java
@@ -22,6 +22,7 @@ import com.dalcoomi.member.application.MemberService;
 import com.dalcoomi.member.dto.LeaderTransferInfo;
 import com.dalcoomi.member.dto.MemberInfo;
 import com.dalcoomi.member.dto.request.SignUpRequest;
+import com.dalcoomi.member.dto.request.UpdateProfileRequest;
 import com.dalcoomi.member.dto.request.WithdrawRequest;
 import com.dalcoomi.member.dto.response.GetMemberResponse;
 import com.dalcoomi.member.dto.response.SignUpResponse;
@@ -64,6 +65,18 @@ public class MemberController {
 		MemberInfo memberInfo = memberService.get(memberId);
 
 		return GetMemberResponse.from(memberInfo);
+	}
+
+	@PatchMapping("/profile")
+	@ResponseStatus(OK)
+	public void updateProfile(@AuthMember Long memberId, @RequestBody @Valid UpdateProfileRequest request) {
+		MemberInfo memberInfo = MemberInfo.builder()
+			.name(request.name())
+			.birthday(request.birthday())
+			.gender(request.gender())
+			.build();
+
+		memberService.updateProfile(memberId, memberInfo);
 	}
 
 	@PatchMapping

--- a/src/test/java/com/dalcoomi/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/dalcoomi/auth/presentation/AuthControllerTest.java
@@ -72,7 +72,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 로그인 실패")
-	void login_failure() throws Exception {
+	void login_fail() throws Exception {
 		// given
 		LoginRequest request = new LoginRequest("123", KAKAO);
 
@@ -150,7 +150,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 이미 로그아웃된 상태이므로 로그아웃 실패")
-	void already_logged_out_logout_failure() throws Exception {
+	void already_logged_out_logout_fail() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
 		member = memberRepository.save(member);
@@ -188,7 +188,7 @@ class AuthControllerTest extends AbstractContainerBaseTest {
 	@Test
 	@DisplayName("통합 테스트 - 토큰 재발급 실패")
 	@WithMockCustomUser()
-	void reissue_token_failure() throws Exception {
+	void reissue_token_fail() throws Exception {
 		// given
 		Long memberId = 1L;
 		String key = memberId + REFRESH_TOKEN_REDIS_KEY_SUFFIX;

--- a/src/test/java/com/dalcoomi/fixture/MemberFixture.java
+++ b/src/test/java/com/dalcoomi/fixture/MemberFixture.java
@@ -9,7 +9,7 @@ public final class MemberFixture {
 	public static Member getMember1() {
 		String email = "abc1@gmail.com";
 		String name = "가나다";
-		String nickname = "가나다#1234";
+		String nickname = "가나다아";
 		LocalDate birthday = LocalDate.of(2000, 1, 1);
 		String gender = "남성";
 		String profileImageUrl = "https://profile.com/1";

--- a/src/test/java/com/dalcoomi/image/application/S3ServiceTest.java
+++ b/src/test/java/com/dalcoomi/image/application/S3ServiceTest.java
@@ -1,0 +1,213 @@
+package com.dalcoomi.image.application;
+
+import static com.dalcoomi.image.constant.ImageConstants.S3_PROFILE_IMAGE_PATH;
+import static java.util.Objects.requireNonNull;
+import static org.apache.commons.imaging.formats.tiff.constants.TiffTagConstants.TIFF_TAG_ORIENTATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
+import org.apache.commons.imaging.formats.tiff.write.TiffOutputDirectory;
+import org.apache.commons.imaging.formats.tiff.write.TiffOutputSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dalcoomi.common.error.exception.ImageException;
+import com.dalcoomi.fixture.MemberFixture;
+import com.dalcoomi.image.infrastructure.S3Adapter;
+import com.dalcoomi.member.domain.Member;
+import com.dalcoomi.member.dto.AvatarInfo;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+	private static final String IMAGE_BASE_URL = "https://bucket.s3.amazonaws.com/";
+
+	@InjectMocks
+	private S3Service s3Service;
+
+	@Mock
+	private S3Adapter s3Adapter;
+
+	private BufferedImage createTestImage() {
+		BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+		Graphics2D graphics = image.createGraphics();
+
+		graphics.setColor(Color.WHITE);
+		graphics.fillRect(0, 0, 100, 50);
+		graphics.setColor(Color.BLACK);
+		graphics.fillRect(0, 50, 100, 50);
+		graphics.dispose();
+
+		return image;
+	}
+
+	private byte[] createDummyImageData(int orientation) throws IOException {
+		BufferedImage image = createTestImage();
+
+		// 생성된 이미지를 JPG 형식의 바이트 배열로 변환
+		ByteArrayOutputStream initialBaos = new ByteArrayOutputStream();
+		ImageIO.write(image, "jpg", initialBaos);
+		byte[] imageBytes = initialBaos.toByteArray();
+
+		// EXIF orientation 추가
+		ByteArrayOutputStream finalBaos = new ByteArrayOutputStream();
+		TiffOutputSet outputSet = new TiffOutputSet();
+		TiffOutputDirectory rootDirectory = outputSet.getOrCreateRootDirectory();
+
+		// 3 = 180도 회전
+		rootDirectory.add(TIFF_TAG_ORIENTATION, (short)orientation);
+
+		// 기존 이미지에 EXIF 메타데이터를 추가하여 새로운 이미지 생성
+		new ExifRewriter().updateExifMetadataLossless(imageBytes, finalBaos, outputSet);
+
+		return finalBaos.toByteArray();
+	}
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(s3Service, "imageBaseUrl", IMAGE_BASE_URL);
+	}
+
+	@Test
+	@DisplayName("회원 프로필 사진 수정 성공")
+	void update_profile_image_success() throws Exception {
+		// given
+		String currentImageUrl = IMAGE_BASE_URL + "profile/old-image.jpg";
+		Member member = spy(MemberFixture.getMember1());
+		when(member.getProfileImageUrl()).thenReturn(currentImageUrl);
+
+		AvatarInfo avatarInfo = AvatarInfo.builder()
+			.member(member)
+			.defaultImage(false)
+			.build();
+
+		MockMultipartFile newImage = new MockMultipartFile("image", "new.jpg", IMAGE_JPEG_VALUE,
+			createDummyImageData(1));
+		String expectedNewUrl = IMAGE_BASE_URL + "profile/new-123.jpg";
+
+		given(s3Adapter.uploadFile(any(byte[].class), anyString(), anyString())).willReturn(expectedNewUrl);
+		doNothing().when(s3Adapter).deleteFile(anyString());
+
+		// when
+		String result = s3Service.handleAvatar(false, avatarInfo, newImage);
+
+		// then
+		assertThat(result).isEqualTo(expectedNewUrl);
+		verify(s3Adapter).deleteFile("profile/old-image.jpg");
+		verify(s3Adapter).uploadFile(any(byte[].class), eq(S3_PROFILE_IMAGE_PATH), eq("jpg"));
+	}
+
+	@Test
+	@DisplayName("회원 프로필 사진 삭제 성공")
+	void delete_profile_image_success() {
+		// given
+		String currentImageUrl = IMAGE_BASE_URL + "profile/current-image.jpg";
+		Member member = spy(MemberFixture.getMember1());
+		when(member.getProfileImageUrl()).thenReturn(currentImageUrl);
+
+		AvatarInfo avatarInfo = AvatarInfo.builder()
+			.member(member)
+			.defaultImage(false)
+			.build();
+
+		doNothing().when(s3Adapter).deleteFile(anyString());
+
+		// when
+		String result = s3Service.handleAvatar(true, avatarInfo, null);
+
+		// then
+		assertThat(result).isNull();
+		verify(s3Adapter).deleteFile("profile/current-image.jpg");
+		verify(s3Adapter, never()).uploadFile(any(), anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("기본 이미지 상태에서 삭제 요청 시 현재 URL 반환 성공")
+	void delete_default_image_returns_current_url_success() {
+		// given
+		Member member = MemberFixture.getMember1();
+		AvatarInfo avatarInfo = AvatarInfo.builder()
+			.member(member)
+			.defaultImage(true)
+			.build();
+
+		String currentUrl = member.getProfileImageUrl();
+
+		// when
+		String result = s3Service.handleAvatar(true, avatarInfo, null);
+
+		// then
+		assertThat(result).isEqualTo(currentUrl);
+		verify(s3Adapter, never()).deleteFile(anyString());
+	}
+
+	@Test
+	@DisplayName("지원하지 않는 이미지 형식으로 업로드 실패")
+	void upload_profile_image_unsupported_format_error() throws IOException {
+		// given
+		Member member = MemberFixture.getMember1();
+		AvatarInfo avatarInfo = AvatarInfo.builder().member(member).defaultImage(false).build();
+		MockMultipartFile image = new MockMultipartFile("image", "test.gif", "image/gif", createDummyImageData(1));
+
+		// when & then
+		assertThrows(ImageException.class, () -> s3Service.handleAvatar(false, avatarInfo, image));
+	}
+
+	@Test
+	@DisplayName("orientation이 3일 때 이미지 180도 회전 성공")
+	void rotate_image_orientation_3_success() throws IOException {
+		// given
+		BufferedImage originalImage = createTestImage();
+		MockMultipartFile image = new MockMultipartFile("image", "test.jpg", IMAGE_JPEG_VALUE, createDummyImageData(3));
+
+		// when
+		BufferedImage rotatedImage = ReflectionTestUtils.invokeMethod(s3Service, "rotateImageIfRequired", originalImage,
+			image);
+
+		// then
+		assertThat(requireNonNull(rotatedImage).getRGB(50, 25)).isEqualTo(Color.BLACK.getRGB());
+		assertThat(requireNonNull(rotatedImage).getRGB(50, 75)).isEqualTo(Color.WHITE.getRGB());
+	}
+
+	@Test
+	@DisplayName("orientation이 6일 때 이미지 90도 회전 성공")
+	void rotate_image_orientation_6_success() throws IOException {
+		// given
+		BufferedImage originalImage = createTestImage();
+		MockMultipartFile image = new MockMultipartFile("image", "test.jpg", IMAGE_JPEG_VALUE, createDummyImageData(6));
+
+		// when
+		BufferedImage rotatedImage = ReflectionTestUtils.invokeMethod(s3Service, "rotateImageIfRequired",
+			originalImage, image);
+
+		// then
+		assertThat(requireNonNull(rotatedImage).getRGB(25, 50)).isEqualTo(Color.BLACK.getRGB());
+		assertThat(requireNonNull(rotatedImage).getRGB(75, 50)).isEqualTo(Color.WHITE.getRGB());
+	}
+}

--- a/src/test/java/com/dalcoomi/image/infrastructure/S3AdapterTest.java
+++ b/src/test/java/com/dalcoomi/image/infrastructure/S3AdapterTest.java
@@ -1,0 +1,73 @@
+package com.dalcoomi.image.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dalcoomi.common.error.exception.ImageException;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@ExtendWith(MockitoExtension.class)
+class S3AdapterTest {
+
+	@InjectMocks
+	private S3Adapter s3Adapter;
+
+	@Mock
+	private S3Client s3Client;
+
+	@Value("${aws.s3.image-base-url}")
+	private String imageBaseUrl;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(s3Adapter, "bucketName", "test-bucket");
+	}
+
+	@Test
+	@DisplayName("파일 업로드 성공")
+	void upload_file_success() throws Exception {
+		// given
+		byte[] fileData = "test data".getBytes();
+		String folderPath = "test/folder";
+		String extension = "jpg";
+
+		// when
+		String result = s3Adapter.uploadFile(fileData, folderPath, extension);
+
+		// then
+		assertThat(result).startsWith(imageBaseUrl + "test/folder/");
+		verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+	}
+
+	@Test
+	@DisplayName("S3 업로드 실패")
+	void upload_file_S3_error() {
+		// given
+		byte[] fileData = "test data".getBytes();
+		String folderPath = "test/folder";
+		String extension = "jpg";
+
+		given(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).willThrow(
+			S3Exception.builder().build());
+
+		// when & then
+		assertThrows(ImageException.class, () -> s3Adapter.uploadFile(fileData, folderPath, extension));
+	}
+}

--- a/src/test/java/com/dalcoomi/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/dalcoomi/member/presentation/MemberControllerTest.java
@@ -48,6 +48,7 @@ import com.dalcoomi.member.domain.SocialConnection;
 import com.dalcoomi.member.domain.Withdrawal;
 import com.dalcoomi.member.dto.LeaderTransferInfo;
 import com.dalcoomi.member.dto.request.SignUpRequest;
+import com.dalcoomi.member.dto.request.UpdateProfileRequest;
 import com.dalcoomi.member.dto.request.WithdrawRequest;
 import com.dalcoomi.team.application.repository.TeamMemberRepository;
 import com.dalcoomi.team.application.repository.TeamRepository;
@@ -185,6 +186,41 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 			.andExpect(jsonPath("$.birthday").value(member.getBirthday().toString()))
 			.andExpect(jsonPath("$.gender").value(member.getGender()))
 			.andExpect(jsonPath("$.profileImageUrl").value(member.getProfileImageUrl()))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("통합 테스트 - 회원 정보 수정 성공")
+	void update_member_success() throws Exception {
+		// given
+		Member member = MemberFixture.getMember1();
+		member = memberRepository.save(member);
+
+		SocialConnection socialConnection = SocialConnectionFixture.getSocialConnection1(member);
+		socialConnectionRepository.save(socialConnection);
+
+		// 인증 설정
+		setAuthentication(member.getId());
+
+		String name = "아야어여";
+		String nickname = "무요";
+		LocalDate birthday = LocalDate.of(1990, 1, 1);
+		String gender = "여성";
+
+		UpdateProfileRequest request = new UpdateProfileRequest(name, nickname, birthday, gender);
+
+		// when & then
+		String json = objectMapper.writeValueAsString(request);
+
+		// when & then
+		mockMvc.perform(patch("/api/members/profile")
+				.contentType(APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.name").value(name))
+			.andExpect(jsonPath("$.nickname").value(nickname))
+			.andExpect(jsonPath("$.birthday").value(birthday.toString()))
+			.andExpect(jsonPath("$.gender").value(gender))
 			.andDo(print());
 	}
 

--- a/src/test/java/com/dalcoomi/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/dalcoomi/member/presentation/MemberControllerTest.java
@@ -114,7 +114,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 이름 길이 초과 회원가입 실패")
-	void name_length_over_sign_up_failure() throws Exception {
+	void name_length_over_sign_up_fail() throws Exception {
 		// given
 		String socialId = "12345";
 		String email = "test@example.com";
@@ -139,7 +139,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 이미 존재하는 회원은 회원가입 실패")
-	void already_exists_sign_up_failure() throws Exception {
+	void already_exists_sign_up_fail() throws Exception {
 		// given
 		Member testMember = MemberFixture.getMember1();
 
@@ -225,6 +225,37 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 	}
 
 	@Test
+	@DisplayName("통합 테스트 - 닉네임 중복 시 회원 정보 수정 실패")
+	void update_member_nickname_conflict_fail() throws Exception {
+		// given
+		Member member = MemberFixture.getMember1();
+		member = memberRepository.save(member);
+
+		SocialConnection socialConnection = SocialConnectionFixture.getSocialConnection1(member);
+		socialConnectionRepository.save(socialConnection);
+
+		// 인증 설정
+		setAuthentication(member.getId());
+
+		String name = "아야어여";
+		String nickname = "가나다아";
+		LocalDate birthday = LocalDate.of(1990, 1, 1);
+		String gender = "여성";
+
+		UpdateProfileRequest request = new UpdateProfileRequest(name, nickname, birthday, gender);
+
+		// when & then
+		String json = objectMapper.writeValueAsString(request);
+
+		// when & then
+		mockMvc.perform(patch("/api/members/profile")
+				.contentType(APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isConflict())
+			.andDo(print());
+	}
+
+	@Test
 	@DisplayName("통합 테스트 - 고정 사유로 회원탈퇴 성공")
 	void withdraw_member_with_predefined_reason_success() throws Exception {
 		// given
@@ -291,7 +322,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 기타 사유 누락으로 인한 회원탈퇴 실패")
-	void withdraw_member_other_reason_missing_failure() throws Exception {
+	void withdraw_member_other_reason_missing_fail() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
 		member = memberRepository.save(member);
@@ -313,7 +344,7 @@ class MemberControllerTest extends AbstractContainerBaseTest {
 
 	@Test
 	@DisplayName("통합 테스트 - 기타 사유 초과로 인한 회원탈퇴 실패")
-	void withdraw_member_other_reason_too_long_failure() throws Exception {
+	void withdraw_member_other_reason_too_long_fail() throws Exception {
 		// given
 		Member member = MemberFixture.getMember1();
 		member = memberRepository.save(member);


### PR DESCRIPTION
**📋 Checklist**

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `[#1]feat: 회원 조회 기능 구현`)
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드에 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?

**🎟️ Issue**

- close #75 

**✅ Tasks**

- 프로필 사진 수정 API 구현
  - 요청 파라미터: 사진 삭제 여부, 사진 파일
  - (프사 등록)삭제 여부 ``false``고 현재 기본 사진일 경우, S3에 새로운 사진 파일 등록하고, DB에 URL 저장
  - (프사 수정)삭제 여부 ``false``고 현재 기본 사진 아닐 경우, S3에서 기존 사진 삭제 후 새로운 사진 파일 등록하고, DB에 URL 저장
  - (프사 삭제)삭제 여부 ``true``고 현재 기본 사진 아닐 경우, S3에서 기존 사진 삭제
  - (프사 삭제 예외 처리)삭제 여부 ``true``고 현재 기본 사진일 경우, 아무런 작업 x
- 회원 정보 수정 API 구현
  - ``existsByNickname`` 메서드로 닉네임 중복 조회
- S3 환경 분리
  - ``local``, ``dev``와 ``prod`` 분리
- 라이브러리 설치
  - ``S3 SDK``, ``Thumbnailator``, ``metadata-extractor``, ``commons-imaging``


